### PR TITLE
Release 1.0.0.0 (develop)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # Revision history for collection-server
 
+## 1.0.0.0  -- 2018-02-25
+
+* update Dockerfile for open sourcing
+* update README for open sourcing
+* fix travis configuration and failures
+
 ## 0.1.3.0  -- 2018-02-09
 
 * add CORS support

--- a/collection-server.cabal
+++ b/collection-server.cabal
@@ -1,5 +1,5 @@
 name:                collection-server
-version:             0.1.3.0
+version:             1.0.0.0
 synopsis:            Static Resource Server for application/vnd.collection+json
 
 description:         

--- a/collection-server.cabal
+++ b/collection-server.cabal
@@ -127,7 +127,7 @@ test-suite collection-server-tests
     , http-media           == 0.6.*
     , network-arbitrary    == 0.3.*
     , network-uri          == 2.6.*
-    , QuickCheck           == 2.9.*
+    , QuickCheck           >= 2.9 && < 2.11
     , quickcheck-instances == 0.3.*
     , servant              == 0.11.*
     , servant-server       == 0.11.*

--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,7 @@
 }:
 mkDerivation {
   pname = "collection-server";
-  version = "0.1.3.0";
+  version = "1.0.0.0";
   src = ./.;
   isLibrary = false;
   isExecutable = true;


### PR DESCRIPTION
I've gone with 1.0.0.0 due to this being the first release in the open
source epoc.  Structurally, we could go with a patch level release, but
due to the change in the docker image build process as well as the
image's name and tag structure, I'm making this an epoch release.